### PR TITLE
Hypernym Algorithm

### DIFF
--- a/WSD/src/cass/languageTool/LanguageTool.java
+++ b/WSD/src/cass/languageTool/LanguageTool.java
@@ -59,13 +59,18 @@ public class LanguageTool implements Lemmatizer, Tokenizer, WordNet {
 	}
 
 	@Override
-	public List<WordSense> getSenses(String word) {
+	public Set<WordSense> getSenses(String word) {
 		return wordNet.getSenses(word);
 	}
 
 	@Override
 	public String getDefinition(WordSense sense) {
 		return wordNet.getDefinition(sense);
+	}
+
+	@Override
+	public Set<WordSense> getHypernyms(WordSense sense) {
+		return wordNet.getHypernyms(sense);
 	}
 		
 }

--- a/WSD/src/cass/languageTool/wordNet/EnWordNet.java
+++ b/WSD/src/cass/languageTool/wordNet/EnWordNet.java
@@ -1,6 +1,5 @@
 package cass.languageTool.wordNet;
 
-import java.util.List;
 import java.util.Set;
 
 public class EnWordNet implements WordNet {
@@ -16,13 +15,19 @@ public class EnWordNet implements WordNet {
 	}
 
 	@Override
-	public List<WordSense> getSenses(String word) {
+	public Set<WordSense> getSenses(String word) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public String getDefinition(WordSense sense) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Set<WordSense> getHypernyms(WordSense sense) {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/WSD/src/cass/languageTool/wordNet/TestWordNet.java
+++ b/WSD/src/cass/languageTool/wordNet/TestWordNet.java
@@ -1,7 +1,6 @@
 package cass.languageTool.wordNet;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 
 public class TestWordNet implements WordNet {
@@ -15,12 +14,12 @@ public class TestWordNet implements WordNet {
 	}
 
 	@Override
-	public List<WordSense> getSenses(String word) {
-		List<WordSense> list = new ArrayList<>(numberOfSenses);
+	public Set<WordSense> getSenses(String word) {
+		Set<WordSense> set = new HashSet<>(numberOfSenses);
 		for (int i = 0; i < numberOfSenses; i++) {
-			list.add(new WordSense(word + i));
+			set.add(new WordSense(word + i));
 		}
-		return list;
+		return set;
 	}
 
 	@Override
@@ -40,6 +39,12 @@ public class TestWordNet implements WordNet {
 		}
 		
 		return gloss;
+	}
+
+	@Override
+	public Set<WordSense> getHypernyms(WordSense sense) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/WSD/src/cass/languageTool/wordNet/WordNet.java
+++ b/WSD/src/cass/languageTool/wordNet/WordNet.java
@@ -1,12 +1,12 @@
 package cass.languageTool.wordNet;
 
-import java.util.List;
 import java.util.Set;
 
 public interface WordNet {
 	Set<String> getSynonyms(WordSense sense);
-	List<WordSense> getSenses(String word);
+	Set<WordSense> getSenses(String word);
 	String getDefinition(WordSense sense);
+	Set<WordSense> getHypernyms(WordSense sense);
 	
 	// TODO: identify full WordNet interface requirements
 }

--- a/WSD/src/cass/libreOffice/LibreOfficeCass.java
+++ b/WSD/src/cass/libreOffice/LibreOfficeCass.java
@@ -3,6 +3,7 @@ package cass.libreOffice;
 import java.util.List;
 
 import cass.languageTool.Language;
+import cass.languageTool.wordNet.WordSense;
 import cass.wsd.*;
 
 public class LibreOfficeCass {
@@ -25,7 +26,7 @@ public class LibreOfficeCass {
 	}
 	
 	public String[][] getSynonyms(String algorithm) {
-		List<ScoredSense> rankedSenses = null;
+		List<WordSense> rankedSenses = null;
 		
 		switch (algorithm) {
 		case "LeskWithWordNet":
@@ -39,7 +40,7 @@ public class LibreOfficeCass {
 		return convert(rankedSenses);
 	}
 
-	private String[][] convert(List<ScoredSense> senses) {
+	private String[][] convert(List<WordSense> senses) {
 		return null;
 	}
 	

--- a/WSD/src/cass/wsd/Algorithm.java
+++ b/WSD/src/cass/wsd/Algorithm.java
@@ -1,5 +1,6 @@
 package cass.wsd;
 
 public enum Algorithm {
-	LESK;
+	LESK,
+	STOCHASTIC_GRAPH;
 }

--- a/WSD/src/cass/wsd/ScoredSense.java
+++ b/WSD/src/cass/wsd/ScoredSense.java
@@ -11,7 +11,7 @@ public class ScoredSense implements Comparable<ScoredSense> {
 	}
 	@Override
 	public int compareTo(ScoredSense o) {
-		return Integer.compare(this.score, o.score);
+		return Integer.compare(getScore(), o.getScore());
 	}
 	public WordSense getSense() {
 		return sense;

--- a/WSD/src/cass/wsd/WSD.java
+++ b/WSD/src/cass/wsd/WSD.java
@@ -130,7 +130,7 @@ public class WSD {
 		// common ancestor has same ancestor path in both lists
 		int depthOfCommonAncestor = 0;
 		for (int i = 0; i < Math.min(ancestors1.size(), ancestors2.size()); i++) {
-			if (ancestors1.get(i) != ancestors2.get(i)) {
+			if (ancestors1.get(i).getId() != ancestors2.get(i).getId()) {
 				depthOfCommonAncestor = i-1;
 			}
 		}

--- a/WSD/src/cass/wsd/WSD.java
+++ b/WSD/src/cass/wsd/WSD.java
@@ -129,10 +129,8 @@ public class WSD {
 		
 		// common ancestor has same ancestor path in both lists
 		int depthOfCommonAncestor = 0;
-		for (int i = 0; i < Math.min(ancestors1.size(), ancestors2.size()); i++) {
-			if (ancestors1.get(i).getId() != ancestors2.get(i).getId()) {
-				depthOfCommonAncestor = i-1;
-			}
+		while(ancestors1.get(depthOfCommonAncestor+1).getId() != ancestors2.get(depthOfCommonAncestor+1).getId()) {
+			depthOfCommonAncestor++;
 		}
 		
 		int distanceFromAncestorToS1 = ancestors1.size() - depthOfCommonAncestor;
@@ -158,27 +156,3 @@ public class WSD {
 		return ancestors;
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/WSD/src/cass/wsd/WSD.java
+++ b/WSD/src/cass/wsd/WSD.java
@@ -1,6 +1,7 @@
 package cass.wsd;
 
 import java.util.List;
+import java.util.Random;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.HashSet;
@@ -13,7 +14,10 @@ public class WSD {
 	
 	private LanguageTool lTool;
 	private List<String> context;
+	@SuppressWarnings("unused")
 	private String target;
+	private Random rand = new Random();
+	Set<WordSense> targetSenses;
 	
 	public WSD(String leftContext, String target, String rightContext, Language language) {
 		lTool = new LanguageTool(language);
@@ -23,33 +27,37 @@ public class WSD {
 		context = new ArrayList<String>();
 		context.addAll(lTool.tokenizeAndLemmatize(leftContext));
 		context.addAll(lTool.tokenizeAndLemmatize(rightContext));
+		
+		targetSenses = lTool.getSenses(target);
 	}
 	
 	public List<ScoredSense> rankSynsetsUsing(Algorithm algorithm) {
 		switch (algorithm) {
 		case LESK:
-			return rankSynsetsUsingLesk();
+			return rankSensesUsingLesk();
 
+		case STOCHASTIC_GRAPH:
+			return rankSensesUsingStochasticHypernymDistance();
+			
 		default:
 			// TODO throw proper exception
 			return null;
 		}
 	}
 	
-	private List<ScoredSense> rankSynsetsUsingLesk() {
-		List<WordSense> senses = lTool.getSenses(target);
+	private List<ScoredSense> rankSensesUsingLesk() {
 		
 		// context set is set of words in context
 		Set<String> contextSet = new HashSet<String>(context);
 		
 		Set<String> glossSet = new HashSet<String>();
-		List<ScoredSense> scoredSynsets= new ArrayList<ScoredSense>();
+		List<ScoredSense> scoredSenses= new ArrayList<ScoredSense>();
 		
 		// for every set of synonyms in the list
-		for (WordSense sense : senses) {
+		for (WordSense targetSense : targetSenses) {
 			// clear and add lemmatized tokens of gloss to set
 			glossSet.clear();
-			String definition = lTool.getDefinition(sense);
+			String definition = lTool.getDefinition(targetSense);
 			glossSet.addAll(lTool.tokenizeAndLemmatize(definition));
 			
 			// find intersection of sets
@@ -58,13 +66,101 @@ public class WSD {
 			// score is cardinality of intersection
 			int score = glossSet.size();
 			
-			scoredSynsets.add(new ScoredSense(sense, score));
+			scoredSenses.add(new ScoredSense(targetSense, score));
 		}
 		
 		// sort in descending order
-		Collections.sort(scoredSynsets);
-		Collections.reverse(scoredSynsets);
+		Collections.sort(scoredSenses);
+		Collections.reverse(scoredSenses);
 		
-		return scoredSynsets;
+		return scoredSenses;
+	}
+	
+	private List<ScoredSense> rankSensesUsingStochasticHypernymDistance() {
+		List<ScoredSense> scoredSenses= new ArrayList<ScoredSense>();
+		
+		for (WordSense targetSense : targetSenses) {
+			int senseScore = 0;
+			for (String contextWord : context) {
+				Set<WordSense> contextWordSenses = lTool.getSenses(contextWord);
+				int bestScore = 0;
+				for (WordSense contextWordSense : contextWordSenses) {
+					int currentScore = getHypernymDistanceScore(targetSense, contextWordSense);
+					if (currentScore > bestScore) {
+						bestScore = currentScore;
+					}
+				}
+				senseScore += bestScore;
+			}
+			scoredSenses.add(new ScoredSense(targetSense, senseScore));
+		}
+		
+		Collections.sort(scoredSenses);
+		Collections.reverse(scoredSenses);
+		
+		return scoredSenses;
+	}
+	
+	private int getHypernymDistanceScore(WordSense sense1, WordSense sense2) {
+		
+		List<WordSense> ancestors1 = getHypernymAncestors(sense1);
+		List<WordSense> ancestors2 = getHypernymAncestors(sense2);
+		
+		Collections.reverse(ancestors1);
+		Collections.reverse(ancestors2);
+		
+		// common ancestor has same ancestor path in both lists
+		int depthOfCommonAncestor = 0;
+		for (int i = 0; i < Math.min(ancestors1.size(), ancestors2.size()); i++) {
+			if (ancestors1.get(i) != ancestors2.get(i)) {
+				depthOfCommonAncestor = i-1;
+			}
+		}
+		
+		int distanceFromAncestorToS1 = ancestors1.size() - depthOfCommonAncestor;
+		int distanceFromAncestorToS2 = ancestors2.size() - depthOfCommonAncestor;
+		
+		int distanceBetweenSenses = distanceFromAncestorToS1 + distanceFromAncestorToS2;
+		
+		return distanceBetweenSenses;
+	}
+	
+	private List<WordSense> getHypernymAncestors(WordSense sense) {
+		List<WordSense> ancestors = new ArrayList<WordSense>();
+		int size, randomIndex;
+		while (sense.getId() != "entity") {
+			Set<WordSense> hypernyms = lTool.getHypernyms(sense);
+			size = hypernyms.size();
+			randomIndex = rand.nextInt(size);
+			WordSense[] hypernymArray = new WordSense[size];
+			hypernyms.toArray(hypernymArray);
+			sense = hypernymArray[randomIndex];
+			ancestors.add(sense);
+		}
+		return ancestors;
 	}
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/WSD/src/cass/wsd/WSD.java
+++ b/WSD/src/cass/wsd/WSD.java
@@ -31,21 +31,34 @@ public class WSD {
 		targetSenses = lTool.getSenses(target);
 	}
 	
-	public List<ScoredSense> rankSynsetsUsing(Algorithm algorithm) {
+	public List<WordSense> rankSynsetsUsing(Algorithm algorithm) {
+		
+		List<ScoredSense> scoredSenses;
+		List<WordSense> rankedSenses = new ArrayList<WordSense>();
+		
 		switch (algorithm) {
 		case LESK:
-			return rankSensesUsingLesk();
+			scoredSenses = rankSensesUsingLesk();
+			break;
 
 		case STOCHASTIC_GRAPH:
-			return rankSensesUsingStochasticHypernymDistance();
+			scoredSenses = rankSensesUsingStochasticHypernymDistance();
+			break;
 			
 		default:
 			// TODO throw proper exception
 			return null;
 		}
+		
+		// convert ScoredSense to WordSense, discard score
+		for (ScoredSense wordSense : scoredSenses) {
+			rankedSenses.add(wordSense.getSense());
+		}
+		
+		return rankedSenses;
 	}
 	
-	private List<ScoredSense> rankSensesUsingLesk() {
+	List<ScoredSense> rankSensesUsingLesk() {
 		
 		// context set is set of words in context
 		Set<String> contextSet = new HashSet<String>(context);
@@ -76,7 +89,7 @@ public class WSD {
 		return scoredSenses;
 	}
 	
-	private List<ScoredSense> rankSensesUsingStochasticHypernymDistance() {
+	List<ScoredSense> rankSensesUsingStochasticHypernymDistance() {
 		List<ScoredSense> scoredSenses= new ArrayList<ScoredSense>();
 		
 		for (WordSense targetSense : targetSenses) {

--- a/WSD/src/cass/wsd/WSD.java
+++ b/WSD/src/cass/wsd/WSD.java
@@ -81,12 +81,17 @@ public class WSD {
 		
 		for (WordSense targetSense : targetSenses) {
 			int senseScore = 0;
+		
 			for (String contextWord : context) {
+				
+				// for each sense of the current context word, find the sense with the minimum distance to the current target sense
 				Set<WordSense> contextWordSenses = lTool.getSenses(contextWord);
+				
 				int bestScore = 0;
 				for (WordSense contextWordSense : contextWordSenses) {
+					
 					int currentScore = getHypernymDistanceScore(targetSense, contextWordSense);
-					if (currentScore > bestScore) {
+					if (currentScore < bestScore) {
 						bestScore = currentScore;
 					}
 				}
@@ -95,8 +100,8 @@ public class WSD {
 			scoredSenses.add(new ScoredSense(targetSense, senseScore));
 		}
 		
+		// sort in ascending order
 		Collections.sort(scoredSenses);
-		Collections.reverse(scoredSenses);
 		
 		return scoredSenses;
 	}

--- a/WSD/test/cass/wsd/TestLesk.java
+++ b/WSD/test/cass/wsd/TestLesk.java
@@ -14,7 +14,7 @@ public class TestLesk {
 	@Test
 	public void test() {
 		WSD wsd = new WSD("The", "bass", "makes low musical sounds", Language.TEST);
-		List<ScoredSense> ranked = wsd.rankSynsetsUsing(Algorithm.LESK);
+		List<ScoredSense> ranked = wsd.rankSensesUsingLesk();
 		
 		List<String> properID = Arrays.asList("bass0", "bass1");
 		List<Integer> properScore = Arrays.asList(3,1);


### PR DESCRIPTION
added set of methods to do graph similarity comparison to rank senses

for each sense of the target word the algorithm gets the gets the distance to the best-matching (determined my minimum distance) sense of each context word sense. The score for the target word sense is the sum of each best-matching context word sense distance.

manually defining hypernym relationships in the TestWordNet class was skipped. Unless agreed differently, we should test this algorithm using an actual wordNet. Defining the hypernym relationships would be manually intensive and not give much benefit.

changed method visibility in WSD

made actual wsd algorithms package visible so they can be used in testing
made public method with Algorithm argument return List<WordSense> instead of List<ScoredSense>
