### PR TITLE
made scored versions of algorithms selectable with Algorithm enum

### DIFF
--- a/WSD/src/cass/wsd/WSD.java
+++ b/WSD/src/cass/wsd/WSD.java
@@ -33,22 +33,8 @@ public class WSD {
 	
 	public List<CASSWordSense> rankSynsetsUsing(Algorithm algorithm) {
 		
-		List<ScoredSense> scoredSenses;
+		List<ScoredSense> scoredSenses = scoreSensesUsing(algorithm);
 		List<CASSWordSense> rankedSenses = new ArrayList<CASSWordSense>();
-		
-		switch (algorithm) {
-		case LESK:
-			scoredSenses = rankSensesUsingLesk();
-			break;
-
-		case STOCHASTIC_GRAPH:
-			scoredSenses = rankSensesUsingStochasticHypernymDistance();
-			break;
-			
-		default:
-			// TODO throw proper exception
-			return null;
-		}
 		
 		// convert ScoredSense to WordSense, discard score
 		for (ScoredSense wordSense : scoredSenses) {
@@ -58,7 +44,28 @@ public class WSD {
 		return rankedSenses;
 	}
 	
-	List<ScoredSense> rankSensesUsingLesk() {
+	List<ScoredSense> scoreSensesUsing(Algorithm algorithm) {
+		
+		List<ScoredSense> scoredSenses;
+		
+		switch (algorithm) {
+		case LESK:
+			scoredSenses = scoreSensesUsingLesk();
+			break;
+
+		case STOCHASTIC_GRAPH:
+			scoredSenses = scoreSensesUsingStochasticHypernymDistance();
+			break;
+			
+		default:
+			// TODO throw proper exception
+			return null;
+		}
+		
+		return scoredSenses;
+	}
+	
+	private List<ScoredSense> scoreSensesUsingLesk() {
 		
 		// context set is set of words in context
 		Set<String> contextSet = new HashSet<String>(context);
@@ -89,7 +96,7 @@ public class WSD {
 		return scoredSenses;
 	}
 	
-	List<ScoredSense> rankSensesUsingStochasticHypernymDistance() {
+	private List<ScoredSense> scoreSensesUsingStochasticHypernymDistance() {
 		List<ScoredSense> scoredSenses= new ArrayList<ScoredSense>();
 		
 		for (CASSWordSense targetSense : targetSenses) {

--- a/WSD/test/cass/wsd/Lesk_Test.java
+++ b/WSD/test/cass/wsd/Lesk_Test.java
@@ -2,7 +2,6 @@ package cass.wsd;
 
 import static org.junit.Assert.*;
 
-import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -22,7 +21,7 @@ public class Lesk_Test {
 	@Test
 	public void test() {
 		WSD wsd = new WSD("The", "bass", "makes low musical sounds", Language.TEST);
-		List<ScoredSense> ranked = wsd.rankSensesUsingLesk();
+		List<ScoredSense> ranked = wsd.scoreSensesUsing(Algorithm.LESK);
 		
 		List<String> properID = Arrays.asList("bass0", "bass1");
 		List<Integer> properScore = Arrays.asList(3,1);
@@ -35,7 +34,7 @@ public class Lesk_Test {
 	}
 	
 	@Test
-	public void systemTest() throws MalformedURLException {
+	public void systemTest() {
 		Iterator<TestData> tsg = new TestSentenceGenerator("semcor3.0");
 		
 		int numCorrect = 0;
@@ -43,7 +42,7 @@ public class Lesk_Test {
 		while (tsg.hasNext()) {
 			TestData ts = tsg.next();
 			WSD wsd = new WSD(ts.getLeftContext(), ts.getTarget(), ts.getRightContext(), Language.EN);
-			List<ScoredSense> results = wsd.rankSensesUsingLesk();
+			List<ScoredSense> results = wsd.scoreSensesUsing(Algorithm.LESK);
 
 			Set<String> predicted = new HashSet<String>();
 			


### PR DESCRIPTION
```
previously the rankings (returning CASSWordSense) were selectable with Algorithm, but the tests had to call the algorithms directly
now the scorings (returning ScoredSense) are selectable with Algorithm and the ranking just calls the scoring method and converts the type appropriatly
```
